### PR TITLE
The STATUS command has been added to shortcut list

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 import os
 import os.path
-import subprocess
-import logging
 import json
 import pathlib
+import subprocess
 from sys import stdout
 from gi.repository import Notify
 from ulauncher.api.client.Extension import Extension
@@ -20,9 +19,6 @@ from ulauncher.api.shared.action.HideWindowAction import HideWindowAction
 from ulauncher.api.shared.action.SetUserQueryAction import SetUserQueryAction
 from ulauncher.api.shared.action.ExtensionCustomAction import ExtensionCustomAction
 
-logging.basicConfig()
-logger = logging.getLogger(__name__)
-
 class Utils:
     @staticmethod
     def get_path(filename):
@@ -37,7 +33,7 @@ class Utils:
             message,
             Utils.get_path("images/icon.svg"),
         )
-        notification.set_timeout(1000)
+        notification.set_timeout(2500)
         notification.show()
 
 
@@ -79,7 +75,7 @@ class Nord:
         if not self.is_installed():
             return
         response = subprocess.Popen([self.installed_path, 'status'], stdout=subprocess.PIPE).communicate()[0].decode('utf8').split('\n')
-        logger.info("\n".join(response[1:]))
+            
         Utils.notify( 
             response[0],
             "\n".join(response[1:])

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
 import os
 import os.path
+import subprocess
+import logging
 import json
 import pathlib
+from sys import stdout
 from gi.repository import Notify
 from ulauncher.api.client.Extension import Extension
 from ulauncher.api.client.EventListener import EventListener

--- a/main.py
+++ b/main.py
@@ -176,6 +176,12 @@ class KeywordQueryEventListener(EventListener):
                     description="Disconnect from NordVPN",
                     on_enter=ExtensionCustomAction({"action": "DISCONNECT"}),
                 ),
+                ExtensionResultItem(
+                    icon=Utils.get_path("images/icon.svg"),
+                    name="Status",
+                    description="NordVPN Status",
+                    on_enter=ExtensionCustomAction({"action": "STATUS"}),
+                ),
                 
             ]
         )

--- a/main.py
+++ b/main.py
@@ -196,7 +196,6 @@ class ItemEnterEventListener(EventListener):
             return extension.nord.disconnect()
 
         if action == "STATUS":
-            logging.info("Selected status")
             return extension.nord.status()
 
         if action == "CONNECT_TO_COUNTRY":

--- a/main.py
+++ b/main.py
@@ -79,10 +79,10 @@ class Nord:
         if not self.is_installed():
             return
         response = subprocess.Popen([self.installed_path, 'status'], stdout=subprocess.PIPE).communicate()[0].decode('utf8').split('\n')
-        logger.info(response.join("\n"))
+        logger.info("\n".join(response[1:]))
         Utils.notify( 
             response[0],
-            response[1:].join("\n")
+            "\n".join(response[1:])
         )
 
     def __init__(self):

--- a/main.py
+++ b/main.py
@@ -165,7 +165,7 @@ class KeywordQueryEventListener(EventListener):
                     icon=Utils.get_path("images/icon.svg"),
                     name="Connect",
                     description="Connect to NordVPN: choose from a list of countries",
-                    highlightable=FalseP,
+                    highlightable=False,
                     on_enter=SetUserQueryAction(
                         f'{extension.keyword or "nord"} connect '
                     ),

--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ class Nord:
     def status(self):
         if not self.is_installed():
             return
-        response = subprocess.Popen([self.installed_path, 'status'], stdout.PIPE).communicate()[0].decode('utf8').split('\n')
+        response = subprocess.Popen([self.installed_path, 'status'], stdout=subprocess.PIPE).communicate()[0].decode('utf8').split('\n')
         logger.info(response.join("\n"))
         Utils.notify( 
             response[0],


### PR DESCRIPTION
I've added the NordVPN `status` command to the list of options along with `connect` and `disconnect`.

![Screenshot_20220313_174940](https://user-images.githubusercontent.com/1061673/158072497-ae8ac4d7-b1df-48a4-9761-46572d32b227.png)

The output of the command is sent to `Utils.notify()` with the title being the status "Connected" or "Disconnected".

So the message could be read I also increased the notify timeout to 2500ms so you can see the information provided. E.g. country, IP, etc.

Potential future update:
 * Add setting to change notification time?
 * Change the status results to be list items similar to how [IP analysis does](https://github.com/manahter/ulauncher-IP-Analysis) and allow copying of these values by clicking enter on them.