### PR TITLE
Add alias "c" for connect

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,7 @@ class KeywordQueryEventListener(EventListener):
 
         argument = event.get_argument() or ""
         command, country_query = (argument.split(" ") + [None])[:2]
-        if command in ["connect"]:
+        if command in ["connect", "c"]:
             items.extend(extension.get_country_ext_result_items(country_query))
             return RenderResultListAction(items)
 


### PR DESCRIPTION
This pull request includes a small change to the `main.py` file. The change adds the alias "c" for the "connect" command to improve user convenience.

![image](https://github.com/user-attachments/assets/a70d281b-8453-4eb3-8110-6d174681fad4)


This change keeps consistence with nord cli:

![image](https://github.com/user-attachments/assets/1cc7a5bd-3c00-489c-b415-bef7abd7cc38)
